### PR TITLE
chore: Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "automerge": true,
   "extends": ["config:base", "schedule:weekly"],
+  "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
   "major": {
     "automerge": false
   },


### PR DESCRIPTION
Ignore preset which forces `fix` prefix on commits and therefore resulting in a release